### PR TITLE
Add WordPress plugin

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -3,7 +3,7 @@ module.exports = {
     // Comment and uncomment the desired CMS/backend plugin to switch between data sources
     // 'yaml-homepage-plugin',
     // 'datocms-homepage-plugin',
-    'contentful-homepage-plugin',
+    "contentful-homepage-plugin",
     // 'wordpress-homepage-plugin',
   ],
 }


### PR DESCRIPTION
This was branched from #8 but will update the base to `main` once that's merged.

Because the custom fields in WordPress work differently that the content blocks in other CMSs, this plugin has a mix of interfaces and custom node creation to create the schema used in the starter. In WordPress, some items like Feature, Benefit, and Testimonial are custom post types, and the homepage is a Page with several custom fields.

Because support for  fields as arrays is a paid feature in ACF, I've opted to numbering fields so that users wouldn't be required to purchase the plugin in order to use this starter, though we could add docs and examples of how to refactor the data model to take advantage of that, if needed.