### PR TITLE
Add support for vanilla .env files and add comments

### DIFF
--- a/plugins/contentful-plugin/.env.EXAMPLE
+++ b/plugins/contentful-plugin/.env.EXAMPLE
@@ -1,2 +1,5 @@
+# Create a .env.development and a .env.production file
+# with the following keys.
+# Do NOT check these files into source control
 CONTENTFUL_SPACE_ID=""
 CONTENTFUL_ACCESS_TOKEN=""

--- a/plugins/contentful-plugin/gatsby-config.js
+++ b/plugins/contentful-plugin/gatsby-config.js
@@ -1,3 +1,5 @@
+// support for .env, .env.development, and .env.production
+require("dotenv").config()
 require("dotenv").config({
   path: `.env.${process.env.NODE_ENV}`,
 })

--- a/plugins/datocms-plugin/.env.EXAMPLE
+++ b/plugins/datocms-plugin/.env.EXAMPLE
@@ -1,2 +1,5 @@
+# Create a .env.development and a .env.production file
+# with the following keys.
+# Do NOT check these files into source control
 DATOCMS_API_TOKEN=""
 DATOCMS_ENVIRONMENT=""

--- a/plugins/datocms-plugin/gatsby-config.js
+++ b/plugins/datocms-plugin/gatsby-config.js
@@ -1,3 +1,5 @@
+// support for .env, .env.development, and .env.production
+require("dotenv").config()
 require("dotenv").config({
   path: `.env.${process.env.NODE_ENV}`,
 })

--- a/plugins/drupal-plugin/.env.EXAMPLE
+++ b/plugins/drupal-plugin/.env.EXAMPLE
@@ -1,3 +1,6 @@
+# Create a .env.development and a .env.production file
+# with the following keys.
+# Do NOT check these files into source control
 DRUPAL_BASE_URL=""
 DRUPAL_BASIC_AUTH_USERNAME=""
 DRUPAL_BASIC_AUTH_PASSWORD=""

--- a/plugins/drupal-plugin/gatsby-config.js
+++ b/plugins/drupal-plugin/gatsby-config.js
@@ -1,3 +1,5 @@
+// support for .env, .env.development, and .env.production
+require("dotenv").config()
 require("dotenv").config({
   path: `.env.${process.env.NODE_ENV}`,
 })

--- a/plugins/wordpress-plugin/.env.EXAMPLE
+++ b/plugins/wordpress-plugin/.env.EXAMPLE
@@ -1,1 +1,4 @@
+# Create a .env.development and a .env.production file
+# with the following key.
+# Do NOT check these files into source control
 WPGRAPHQL_URL=""

--- a/plugins/wordpress-plugin/gatsby-config.js
+++ b/plugins/wordpress-plugin/gatsby-config.js
@@ -1,3 +1,5 @@
+// support for .env, .env.development, and .env.production
+require("dotenv").config()
 require("dotenv").config({
   path: `.env.${process.env.NODE_ENV}`,
 })


### PR DESCRIPTION
Attempting to make setup a little more foolproof when a user creates a `.env` file instead of `.env.production` and `.env.development`, which is fairly common. 