### PR TITLE
Add support for Contentful preview in setup script

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -3,8 +3,8 @@ module.exports = {
     // Comment and uncomment the desired CMS/backend plugin to switch between data sources
     // "yaml-plugin",
     // "drupal-plugin",
-    // "contentful-plugin",
-    "datocms-plugin",
+    "contentful-plugin",
+    // "datocms-plugin",
     // "wordpress-plugin",
   ],
 }

--- a/plugins/contentful-plugin/.env.EXAMPLE
+++ b/plugins/contentful-plugin/.env.EXAMPLE
@@ -3,3 +3,6 @@
 # Do NOT check these files into source control
 CONTENTFUL_SPACE_ID=""
 CONTENTFUL_ACCESS_TOKEN=""
+# To enable Content Preview, the following are required:
+CONTENTFUL_HOST=""
+CONTENTFUL_PREVIEW_ACCESS_TOKEN=""

--- a/plugins/contentful-plugin/gatsby-config.js
+++ b/plugins/contentful-plugin/gatsby-config.js
@@ -4,15 +4,23 @@ require("dotenv").config({
   path: `.env.${process.env.NODE_ENV}`,
 })
 
+const contentfulOptions = {
+  downloadLocal: true,
+  spaceId: process.env.CONTENTFUL_SPACE_ID,
+  accessToken: process.env.CONTENTFUL_ACCESS_TOKEN,
+}
+
+if (process.env.CONTENTFUL_HOST) {
+  // enable preview
+  contentfulOptions.host = process.env.CONTENTFUL_HOST
+  contentfulOptions.accessToken = process.env.CONTENTFUL_PREVIEW_ACCESS_TOKEN
+}
+
 module.exports = {
   plugins: [
     {
       resolve: "gatsby-source-contentful",
-      options: {
-        downloadLocal: true,
-        spaceId: process.env.CONTENTFUL_SPACE_ID,
-        accessToken: process.env.CONTENTFUL_ACCESS_TOKEN,
-      },
+      options: contentfulOptions,
     },
     "gatsby-plugin-sharp",
     "gatsby-plugin-image",

--- a/plugins/contentful-plugin/scripts/setup.js
+++ b/plugins/contentful-plugin/scripts/setup.js
@@ -49,7 +49,6 @@ const questions = [
       !process.env.CONTENTFUL_DELIVERY_ACCESS_TOKEN,
     message: "Your Content Delivery API access token",
   },
-  /* TODO: add support for preview in gatsby-config.js
   {
     name: "usePreview",
     type: "confirm",
@@ -64,7 +63,6 @@ const questions = [
       answers.usePreview,
     message: "Your Content Preview API access token",
   },
-  */
 ]
 
 inquirer
@@ -80,7 +78,7 @@ inquirer
         CONTENTFUL_SPACE_ID,
         CONTENTFUL_ACCESS_TOKEN,
         CONTENTFUL_DELIVERY_ACCESS_TOKEN,
-        // CONTENTFUL_PREVIEW_ACCESS_TOKEN,
+        CONTENTFUL_PREVIEW_ACCESS_TOKEN,
       } = process.env
 
       // env vars are given precedence followed by args provided to the setup
@@ -99,7 +97,8 @@ inquirer
         argv.deliveryToken ||
         accessToken
 
-      // previewToken = CONTENTFUL_PREVIEW_ACCESS_TOKEN || argv.previewToken || previewToken;
+      previewToken =
+        CONTENTFUL_PREVIEW_ACCESS_TOKEN || argv.previewToken || previewToken
 
       console.log("Writing config file...")
       const configFiles = [`.env.development`, `.env.production`].map((file) =>
@@ -112,7 +111,7 @@ inquirer
         `# Do NOT commit this file to source control`,
         `CONTENTFUL_SPACE_ID='${spaceId}'`,
         `CONTENTFUL_ACCESS_TOKEN='${accessToken}'`,
-        // !!previewToken && `CONTENTFUL_PREVIEW_ACCESS_TOKEN='${previewToken}'`,
+        !!previewToken && `CONTENTFUL_PREVIEW_ACCESS_TOKEN='${previewToken}'`,
       ]
         .filter(Boolean)
         .join("\n")
@@ -122,12 +121,12 @@ inquirer
         console.log(`Config file ${chalk.yellow(file)} written`)
       })
 
-      // if (previewToken) {
-      //   fs.appendFileSync(
-      //     `.env.development`,
-      //     `\nCONTENTFUL_HOST='preview.contentful.com'`
-      //   );
-      // }
+      if (previewToken) {
+        fs.appendFileSync(
+          `.env.development`,
+          `\nCONTENTFUL_HOST='preview.contentful.com'`
+        )
+      }
 
       return { spaceId, managementToken }
     }


### PR DESCRIPTION
This also needs to be set up in the Contentful space and Gatsby Cloud site, which I've done for the starter repo's demo site, ~~and will add to this development repo's Gatsby Cloud site~~