### PR TITLE
Delete special WpPage nodes

### DIFF
--- a/plugins/wordpress-plugin/gatsby-node.js
+++ b/plugins/wordpress-plugin/gatsby-node.js
@@ -620,6 +620,8 @@ exports.onCreateNode = ({
           ],
         })
 
+        // delete the node because we're not using it in `src/pages/{Page.slug}.js`
+        actions.deleteNode(node, { name: "gatsby-source-wordpress" })
         break
       } else if (node.slug === "about") {
         // console.log("about page node: ", node)
@@ -801,6 +803,9 @@ exports.onCreateNode = ({
             aboutCtaID,
           ],
         })
+
+        // delete the node because we're not using it in `src/pages/{Page.slug}.js`
+        actions.deleteNode(node, { name: "gatsby-source-wordpress" })
       }
       break
     case "WpFeature":
@@ -892,7 +897,7 @@ exports.onCreateNode = ({
         value: metaLinks,
       })
       break
-    default:
-      console.log("Node did not match any expected type: ", node.internal.type)
+    // default:
+    // console.log("Node did not match any expected type: ", node.internal.type)
   }
 }

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -11,41 +11,37 @@ const Fallback = (props) => {
 export default function About(props) {
   const { aboutPage } = props.data
 
-  console.log("about page data: ", aboutPage)
-  return null
-
-  // return (
-  //   <Layout {...aboutPage}>
-  //     {aboutPage.blocks.map((block, i) => {
-  //       const Component = sections[block.blocktype] || Fallback
-  //       return <Component key={block.id} index={i} {...block} />
-  //     })}
-  //   </Layout>
-  // )
+  return (
+    <Layout {...aboutPage}>
+      {aboutPage.blocks.map((block, i) => {
+        const Component = sections[block.blocktype] || Fallback
+        return <Component key={block.id} index={i} {...block} />
+      })}
+    </Layout>
+  )
 }
 
 export const query = graphql`
-  {
+  query {
     aboutPage {
       id
       title
       description
+      image {
+        id
+        url
+      }
+      blocks: content {
+        id
+        blocktype
+        ...AboutHeroContent
+        ...AboutStatListContent
+        ...HomepageProductListContent
+        ...AboutLeadershipContent
+        ...HomepageBenefitListContent
+        ...AboutLogoListContent
+        ...HomepageCtaContent
+      }
     }
   }
 `
-
-// # image {
-//   #   id
-//   #   url
-//   # }
-//   #blocks: content {
-//   # id
-//   # blocktype
-//   # ...AboutHeroContent
-//   # ...AboutStatListContent
-//   # ...HomepageProductListContent
-//   # ...AboutLeadershipContent
-//   # ...HomepageBenefitListContent
-//   # ...AboutLogoListContent
-//   # ...HomepageCtaContent
-//   # }


### PR DESCRIPTION
I'm not sure if this is the best way to handle this, but because we are using `WpPage` for both the generic pages like "Terms" and "Privacy" and the special/custom homepage and "About" pages, this deletes the `WpPage` nodes for the later so that `src/pages/{Page.slug}.js` doesn't create pages for these nodes