### PR TITLE
Fallback for missing Link prop

### DIFF
--- a/src/components/ui.js
+++ b/src/components/ui.js
@@ -136,7 +136,7 @@ export function Kicker({ ...props }) {
 }
 
 export function Link({ to, href, ...props }) {
-  const url = href || to
+  const url = href || to || ""
   if (isAbsoluteURL(url)) {
     return (
       // eslint-disable-next-line jsx-a11y/anchor-has-content


### PR DESCRIPTION
I'm not entirely sure why, but DatoCMS's demo site seems to be failing on this