### PR TITLE
Add PR template for target repos

### DIFF
--- a/docs/pr-template.md
+++ b/docs/pr-template.md
@@ -1,0 +1,5 @@
+**THIS IS A GATSBY STARTER TEMPLATE REPOSITORY**
+
+**Pull requests to this repo will not be accepted. If you would like to contribute, please open a PR in the source repository:**
+
+<https://github.com/gatsbyjs/homepage-starters>

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -102,6 +102,12 @@ const createStarterDist = async (basename) => {
     fs.copySync(src, dest)
   })
 
+  // Copy pull request template to target repos
+  fs.copySync(
+    "docs/pr-template.md",
+    path.join(dir.dist, name, "pull_request_template.md")
+  )
+
   const json = createPackageJSON(name)
   fs.writeFileSync(path.join(dir.dist, name, "package.json"), json, "utf8")
 


### PR DESCRIPTION
This adds a PR template markdown file that will be included in the target starter repos to point contributors back to this development repo, since this repo's publish script will erase any changes made in the target repos.