### PR TITLE
chore: align `Hero` flex `gap` with `Feature`

### DIFF
--- a/src/components/hero.js
+++ b/src/components/hero.js
@@ -17,7 +17,7 @@ export default function Hero(props) {
   return (
     <Section>
       <Container>
-        <Flex variant="responsive">
+        <Flex gap={4} variant="responsive">
           <Box width="half">
             {props.image && (
               <GatsbyImage


### PR DESCRIPTION
Since I'm causing a release because I was too stupid to catch #89 earlier, here's another smol one.

This increases the `gap` for `Hero` to match that of `Feature`:

* before/after  
  <img width="1081" alt="image" src="https://user-images.githubusercontent.com/21834/156272735-b7928926-4196-4a6f-96f7-742f553998f3.png">
* current `Feature` gap:  
  <img width="976" alt="image" src="https://user-images.githubusercontent.com/21834/156272816-61e27cf5-dff9-44f7-9bb1-12fb49ea0e1b.png">
