### PR TITLE
add yarn.lock to files copied in publish script

### DIFF
--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -73,7 +73,13 @@ const createStarterDist = async (basename) => {
   ]
 
   // copy root files
-  const rootFiles = [".gitignore", "src", "gatsby-browser.js", "LICENSE"]
+  const rootFiles = [
+    ".gitignore",
+    "src",
+    "gatsby-browser.js",
+    "LICENSE",
+    "yarn.lock",
+  ]
   rootFiles.forEach((file) => {
     const dest = path.join(dir.dist, name, file)
     console.log(`Copying '${file}' to '${dest}'`)


### PR DESCRIPTION
This (temporarily) fixes an issue with dependencies resulting in starters not working with fresh installs. A follow up PR will come to resolve this within the dependency versions listed within `package.json` itself.

## Testing
I confirmed this worked by running `yarn publish-starters:dry-run` and then going to the `dist/gatsby-starter-contentful-homepage` directory, running `yarn` followed by `yarn start` and confirming the site is able to run.