### PR TITLE
Abstract blog theme API changes

### DIFF
--- a/src/templates/blog-index.tsx
+++ b/src/templates/blog-index.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { graphql } from "gatsby"
 import { GatsbyImage } from "gatsby-plugin-image"
-import Layout from "../components/layout"
+import Layout from "../../src/components/layout"
 import {
   Container,
   FlexList,
@@ -13,7 +13,7 @@ import {
   Kicker,
   Text,
   HomepageImage,
-} from "../components/ui"
+} from "../../src/components/ui"
 import { BlogAuthor, BlogPost } from "./blog-post"
 
 interface PostCardSmallProps {
@@ -83,16 +83,10 @@ function PostCardSmall({
 }
 
 export interface BlogIndexProps {
-  data: {
-    allBlogPost: {
-      nodes: BlogPost[]
-    }
-  }
+  posts: BlogPost[]
 }
 
-export default function BlogIndex(props: BlogIndexProps) {
-  const posts = props.data.allBlogPost.nodes
-
+export default function BlogIndex({ posts }: BlogIndexProps) {
   const featuredPosts = posts.filter((p) => p.category === "Featured")
   const regularPosts = posts.filter((p) => p.category !== "Featured")
 
@@ -123,26 +117,3 @@ export default function BlogIndex(props: BlogIndexProps) {
     </Layout>
   )
 }
-
-export const query = graphql`
-  query {
-    allBlogPost(sort: { fields: date, order: DESC }) {
-      nodes {
-        id
-        slug
-        title
-        excerpt
-        category
-        image {
-          id
-          alt
-          gatsbyImageData(aspectRatio: 2)
-        }
-        author {
-          id
-          name
-        }
-      }
-    }
-  }
-`

--- a/src/templates/blog-index.tsx
+++ b/src/templates/blog-index.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { graphql } from "gatsby"
 import { GatsbyImage } from "gatsby-plugin-image"
-import Layout from "../../src/components/layout"
+import Layout from "../components/layout"
 import {
   Container,
   FlexList,
@@ -13,7 +13,7 @@ import {
   Kicker,
   Text,
   HomepageImage,
-} from "../../src/components/ui"
+} from "../components/ui"
 import { BlogAuthor, BlogPost } from "./blog-post"
 
 interface PostCardSmallProps {

--- a/src/templates/blog-post.css.ts
+++ b/src/templates/blog-post.css.ts
@@ -1,5 +1,5 @@
 import { style, globalStyle } from "@vanilla-extract/css"
-import { theme } from "../theme.css"
+import { theme } from "../../src/theme.css"
 
 export const blogPost = style({
   fontSize: theme.fontSizes[3],

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { graphql } from "gatsby"
 import { GatsbyImage } from "gatsby-plugin-image"
-import Layout from "../../src/components/layout"
+import Layout from "../components/layout"
 import {
   Container,
   Flex,
@@ -11,8 +11,8 @@ import {
   Text,
   Avatar,
   HomepageImage,
-} from "../../src/components/ui"
-import { avatar as avatarStyle } from "../../src/components/ui.css"
+} from "../components/ui"
+import { avatar as avatarStyle } from "../components/ui.css"
 import * as styles from "./blog-post.css"
 
 export interface BlogAuthor {

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -31,6 +31,8 @@ export interface BlogPost {
   html: string
   image: HomepageImage
   author: BlogAuthor
+  next?: BlogPost
+  previous?: BlogPost
 }
 
 export default function BlogPost(props: BlogPost) {

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { graphql } from "gatsby"
 import { GatsbyImage } from "gatsby-plugin-image"
-import Layout from "../components/layout"
+import Layout from "../../src/components/layout"
 import {
   Container,
   Flex,
@@ -11,8 +11,8 @@ import {
   Text,
   Avatar,
   HomepageImage,
-} from "../components/ui"
-import { avatar as avatarStyle } from "../components/ui.css"
+} from "../../src/components/ui"
+import { avatar as avatarStyle } from "../../src/components/ui.css"
 import * as styles from "./blog-post.css"
 
 export interface BlogAuthor {
@@ -33,57 +33,49 @@ export interface BlogPost {
   author: BlogAuthor
 }
 
-export interface BlogPostProps {
-  data: {
-    blogPost: BlogPost
-  }
-}
-
-export default function BlogPost(props: BlogPostProps) {
-  const post = props.data.blogPost
-
+export default function BlogPost(props: BlogPost) {
   return (
-    <Layout {...post} description={post.excerpt}>
+    <Layout {...props} description={props.excerpt}>
       <Container>
         <Box paddingY={5}>
           <Heading as="h1" center>
-            {post.title}
+            {props.title}
           </Heading>
           <Space size={4} />
-          {post.author && (
+          {props.author && (
             <Box center>
               <Flex>
-                {post.author.avatar &&
-                  (!!post.author.avatar.gatsbyImageData ? (
+                {props.author.avatar &&
+                  (!!props.author.avatar.gatsbyImageData ? (
                     <Avatar
-                      {...post.author.avatar}
-                      image={post.author.avatar.gatsbyImageData}
+                      {...props.author.avatar}
+                      image={props.author.avatar.gatsbyImageData}
                     />
                   ) : (
                     <img
-                      src={post.author.avatar.url}
-                      alt={post.author.name}
+                      src={props.author.avatar.url}
+                      alt={props.author.name}
                       className={avatarStyle}
                     />
                   ))}
-                <Text variant="bold">{post.author.name}</Text>
+                <Text variant="bold">{props.author.name}</Text>
               </Flex>
             </Box>
           )}
           <Space size={4} />
-          <Text center>{post.date}</Text>
+          <Text center>{props.date}</Text>
           <Space size={4} />
-          {post.image && (
+          {props.image && (
             <GatsbyImage
-              alt={post.image.alt}
-              image={post.image.gatsbyImageData}
+              alt={props.image.alt}
+              image={props.image.gatsbyImageData}
             />
           )}
           <Space size={5} />
           <div
             className={styles.blogPost}
             dangerouslySetInnerHTML={{
-              __html: post.html,
+              __html: props.html,
             }}
           />
         </Box>
@@ -91,32 +83,3 @@ export default function BlogPost(props: BlogPostProps) {
     </Layout>
   )
 }
-
-export const query = graphql`
-  query ($id: String!) {
-    blogPost(id: { eq: $id }) {
-      id
-      slug
-      title
-      html
-      excerpt
-      date(formatString: "MMMM Do, YYYY")
-      image {
-        id
-        url
-        gatsbyImageData
-        alt
-      }
-      author {
-        id
-        name
-        avatar {
-          id
-          alt
-          gatsbyImageData
-          url
-        }
-      }
-    }
-  }
-`

--- a/themes/gatsby-theme-abstract-blog/README.md
+++ b/themes/gatsby-theme-abstract-blog/README.md
@@ -40,11 +40,9 @@ Add these two templates to your site.
 ```js
 // src/templates/blog-index.js
 import * as React from "react"
-import { graphql, Link } from "gatsby"
+import { Link } from "gatsby"
 
-export default function BlogIndex(props) {
-  const posts = props.data.allBlogPost.nodes
-
+export default function BlogIndex({ posts }) {
   return (
     <div>
       <h1>Blog</h1>
@@ -58,50 +56,24 @@ export default function BlogIndex(props) {
     </div>
   )
 }
-
-export const query = graphql`
-  query {
-    allBlogPost {
-      nodes {
-        id
-        slug
-        title
-      }
-    }
-  }
-`
 ```
 
 ```js
 // src/templates/blog-post.js
 import * as React from "react"
-import { graphql } from "gatsby"
 
 export default function BlogPost(props) {
-  const post = props.data.blogPost
-
   return (
     <div>
-      <h1>{post.title}</h1>
+      <h1>{props.title}</h1>
       <div
         dangerouslySetInnerHTML={{
-          __html: post.html,
+          __html: props.html,
         }}
       />
     </div>
   )
 }
-
-export const query = graphql`
-  query ($id: String!) {
-    blogPost(id: { eq: $id }) {
-      id
-      slug
-      title
-      html
-    }
-  }
-`
 ```
 
 ### Add content source
@@ -136,8 +108,8 @@ module.exports = {
     {
       resolve: "gatsby-theme-abstract-blog",
       options: {
-        postPath: "src/templates/blog-post.js",
-        indexPath: "src/templates/blog-index.js",
+        postPath: "src/templates/blog-post",
+        indexPath: "src/templates/blog-index",
       },
     },
   ],

--- a/themes/gatsby-theme-abstract-blog/README.md
+++ b/themes/gatsby-theme-abstract-blog/README.md
@@ -110,6 +110,7 @@ module.exports = {
       options: {
         postPath: "src/templates/blog-post",
         indexPath: "src/templates/blog-index",
+        customQueries: false,
       },
     },
   ],
@@ -118,3 +119,4 @@ module.exports = {
 
 - `postPath`: relative path to template for the blog post pages
 - `indexPath`: relative path to template for the blog index page
+- `customQueries`: set to `true` to use provided components as page components that include Gatsby GraphQL page queries

--- a/themes/gatsby-theme-abstract-blog/gatsby-node.js
+++ b/themes/gatsby-theme-abstract-blog/gatsby-node.js
@@ -13,7 +13,7 @@ const defaults = {
 
 exports.createSchemaCustomization = async ({ actions }) => {
   actions.createFieldExtension({
-    name: "imagePassthroughArgs",
+    name: "imagePassthroughArguments",
     extend(options) {
       const { args } = getGatsbyImageResolver()
       return {
@@ -26,7 +26,7 @@ exports.createSchemaCustomization = async ({ actions }) => {
     interface Image implements Node {
       id: ID!
       alt: String
-      gatsbyImageData: JSON @imagePassthroughArgs
+      gatsbyImageData: JSON @imagePassthroughArguments
       url: String
     }
 
@@ -50,7 +50,7 @@ exports.createSchemaCustomization = async ({ actions }) => {
   `)
 }
 
-exports.createPages = async ({ actions, graphql, reporter }, _opts = {}) => {
+exports.onCreateWebpackConfig = ({ actions }, _opts = {}) => {
   const components = {}
   const opts = {
     postPath: _opts.postPath || defaults.postPath,
@@ -60,7 +60,7 @@ exports.createPages = async ({ actions, graphql, reporter }, _opts = {}) => {
   try {
     components.post = path.join(global.__GATSBY.root, opts.postPath)
     components.index = path.join(global.__GATSBY.root, opts.indexPath)
-    // todo throw when file not found
+
     if (fs.existsSync(components.post + ".js")) {
       components.post = components.post + ".js"
     } else if (fs.existsSync(components.post + ".tsx")) {
@@ -79,6 +79,22 @@ exports.createPages = async ({ actions, graphql, reporter }, _opts = {}) => {
   } catch (e) {
     reporter.warn(e)
     return
+  }
+
+  actions.setWebpackConfig({
+    resolve: {
+      alias: {
+        "@gatsby-theme-abstract-blog/post": path.resolve(components.post),
+        "@gatsby-theme-abstract-blog/index": path.resolve(components.index),
+      },
+    },
+  })
+}
+
+exports.createPages = async ({ actions, graphql, reporter }) => {
+  const components = {
+    post: path.join(__dirname, "src/post.js"),
+    index: path.join(__dirname, "src/index.js"),
   }
 
   const result = await graphql(`

--- a/themes/gatsby-theme-abstract-blog/gatsby-node.js
+++ b/themes/gatsby-theme-abstract-blog/gatsby-node.js
@@ -55,6 +55,18 @@ exports.onPluginInit = ({ reporter }, _opts = {}) => {
   pluginState.components = components
 }
 
+exports.pluginOptionsSchema = ({ Joi }) => {
+  return Joi.object({
+    postPath: Joi.string().description("File path to blog post template"),
+    indexPath: Joi.string().description(
+      "File path to blog index page template"
+    ),
+    customQueries: Joi.boolean().description(
+      "Use blog templates as page components with custom GraphQL queries"
+    ),
+  })
+}
+
 exports.createSchemaCustomization = async ({ actions }) => {
   actions.createFieldExtension({
     name: "imagePassthroughArguments",

--- a/themes/gatsby-theme-abstract-blog/gatsby-node.js
+++ b/themes/gatsby-theme-abstract-blog/gatsby-node.js
@@ -9,6 +9,7 @@ const { getGatsbyImageResolver } = require("gatsby-plugin-image/graphql-utils")
 const defaults = {
   postPath: "src/templates/blog-post",
   indexPath: "src/templates/blog-index",
+  customQueries: false,
 }
 
 const pluginState = {}
@@ -113,16 +114,19 @@ exports.onCreateWebpackConfig = ({ actions, reporter }, _opts = {}) => {
   })
 }
 
-exports.createPages = async ({ actions, graphql, reporter }) => {
+exports.createPages = async ({ actions, graphql, reporter }, _opts = {}) => {
   const components = pluginState.components
   if (!components || !components.post || !components.index) return
+  const opts = { ...defaults, ..._opts }
 
   reporter.info("[gatsby-theme-abstract-blog] creating pages")
 
-  const templates = {
-    post: path.join(__dirname, "src/post.js"),
-    index: path.join(__dirname, "src/index.js"),
-  }
+  const templates = opts.customQueries
+    ? components
+    : {
+        post: path.join(__dirname, "src/post.js"),
+        index: path.join(__dirname, "src/index.js"),
+      }
 
   const result = await graphql(`
     {

--- a/themes/gatsby-theme-abstract-blog/src/fallback.js
+++ b/themes/gatsby-theme-abstract-blog/src/fallback.js
@@ -1,0 +1,5 @@
+import * as React from "react"
+
+export default function Fallback(props) {
+  return <pre children={JSON.stringify(props, null, 2)} />
+}

--- a/themes/gatsby-theme-abstract-blog/src/index.js
+++ b/themes/gatsby-theme-abstract-blog/src/index.js
@@ -1,0 +1,32 @@
+import * as React from "react"
+import { graphql } from "gatsby"
+import BlogIndex from "@gatsby-theme-abstract-blog/index"
+
+export default function BlogIndexQuery(props) {
+  const posts = props.data.allBlogPost.nodes
+
+  return <BlogIndex posts={posts} />
+}
+
+export const query = graphql`
+  query {
+    allBlogPost(sort: { fields: date, order: DESC }) {
+      nodes {
+        id
+        slug
+        title
+        excerpt
+        category
+        image {
+          id
+          alt
+          gatsbyImageData(aspectRatio: 2)
+        }
+        author {
+          id
+          name
+        }
+      }
+    }
+  }
+`

--- a/themes/gatsby-theme-abstract-blog/src/index.js
+++ b/themes/gatsby-theme-abstract-blog/src/index.js
@@ -20,7 +20,7 @@ export const query = graphql`
         image {
           id
           alt
-          gatsbyImageData(aspectRatio: 2)
+          gatsbyImageData
         }
         author {
           id

--- a/themes/gatsby-theme-abstract-blog/src/post.js
+++ b/themes/gatsby-theme-abstract-blog/src/post.js
@@ -1,0 +1,38 @@
+import * as React from "react"
+import { graphql } from "gatsby"
+import BlogPost from "@gatsby-theme-abstract-blog/post"
+
+export default function BlogPostQuery(props) {
+  const post = props.data.blogPost
+
+  return <BlogPost {...post} />
+}
+
+export const query = graphql`
+  query ($id: String!) {
+    blogPost(id: { eq: $id }) {
+      id
+      slug
+      title
+      html
+      excerpt
+      date(formatString: "MMMM Do, YYYY")
+      image {
+        id
+        url
+        gatsbyImageData
+        alt
+      }
+      author {
+        id
+        name
+        avatar {
+          id
+          alt
+          gatsbyImageData
+          url
+        }
+      }
+    }
+  }
+`

--- a/themes/gatsby-theme-abstract-blog/src/post.js
+++ b/themes/gatsby-theme-abstract-blog/src/post.js
@@ -4,12 +4,13 @@ import BlogPost from "@gatsby-theme-abstract-blog/post"
 
 export default function BlogPostQuery(props) {
   const post = props.data.blogPost
+  const { next, previous } = props.data
 
-  return <BlogPost {...post} />
+  return <BlogPost {...post} next={next} previous={previous} />
 }
 
 export const query = graphql`
-  query ($id: String!) {
+  query ($id: String!, $next: String, $previous: String) {
     blogPost(id: { eq: $id }) {
       id
       slug
@@ -32,6 +33,28 @@ export const query = graphql`
           gatsbyImageData
           url
         }
+      }
+    }
+    previous: blogPost(slug: { eq: $previous }) {
+      id
+      slug
+      title
+      image {
+        id
+        url
+        gatsbyImageData
+        alt
+      }
+    }
+    next: blogPost(slug: { eq: $next }) {
+      id
+      slug
+      title
+      image {
+        id
+        url
+        gatsbyImageData
+        alt
       }
     }
   }

--- a/themes/gatsby-theme-contentful-blog/README.md
+++ b/themes/gatsby-theme-contentful-blog/README.md
@@ -45,11 +45,9 @@ Add these two templates to your site.
 ```js
 // src/templates/blog-index.js
 import * as React from "react"
-import { graphql, Link } from "gatsby"
+import { Link } from "gatsby"
 
-export default function BlogIndex(props) {
-  const posts = props.data.allBlogPost.nodes
-
+export default function BlogIndex({ posts }) {
   return (
     <div>
       <h1>Blog</h1>
@@ -63,50 +61,24 @@ export default function BlogIndex(props) {
     </div>
   )
 }
-
-export const query = graphql`
-  query {
-    allBlogPost {
-      nodes {
-        id
-        slug
-        title
-      }
-    }
-  }
-`
 ```
 
 ```js
 // src/templates/blog-post.js
 import * as React from "react"
-import { graphql } from "gatsby"
 
 export default function BlogPost(props) {
-  const post = props.data.blogPost
-
   return (
     <div>
-      <h1>{post.title}</h1>
+      <h1>{props.title}</h1>
       <div
         dangerouslySetInnerHTML={{
-          __html: post.html,
+          __html: props.html,
         }}
       />
     </div>
   )
 }
-
-export const query = graphql`
-  query ($id: String!) {
-    blogPost(id: { eq: $id }) {
-      id
-      slug
-      title
-      html
-    }
-  }
-`
 ```
 
 ### Add a content model and content
@@ -128,8 +100,8 @@ module.exports = {
     {
       resolve: "gatsby-theme-contentful-blog",
       options: {
-        postPath: "src/templates/blog-post.js",
-        indexPath: "src/templates/blog-index.js",
+        postPath: "src/templates/blog-post",
+        indexPath: "src/templates/blog-index",
       },
     },
   ],

--- a/themes/gatsby-theme-datocms-blog/README.md
+++ b/themes/gatsby-theme-datocms-blog/README.md
@@ -45,11 +45,9 @@ Add these two templates to your site.
 ```js
 // src/templates/blog-index.js
 import * as React from "react"
-import { graphql, Link } from "gatsby"
+import { Link } from "gatsby"
 
-export default function BlogIndex(props) {
-  const posts = props.data.allBlogPost.nodes
-
+export default function BlogIndex({ posts }) {
   return (
     <div>
       <h1>Blog</h1>
@@ -63,50 +61,24 @@ export default function BlogIndex(props) {
     </div>
   )
 }
-
-export const query = graphql`
-  query {
-    allBlogPost {
-      nodes {
-        id
-        slug
-        title
-      }
-    }
-  }
-`
 ```
 
 ```js
 // src/templates/blog-post.js
 import * as React from "react"
-import { graphql } from "gatsby"
 
 export default function BlogPost(props) {
-  const post = props.data.blogPost
-
   return (
     <div>
-      <h1>{post.title}</h1>
+      <h1>{props.title}</h1>
       <div
         dangerouslySetInnerHTML={{
-          __html: post.html,
+          __html: props.html,
         }}
       />
     </div>
   )
 }
-
-export const query = graphql`
-  query ($id: String!) {
-    blogPost(id: { eq: $id }) {
-      id
-      slug
-      title
-      html
-    }
-  }
-`
 ```
 
 ## Options
@@ -118,8 +90,8 @@ module.exports = {
     {
       resolve: "gatsby-theme-datocms-blog",
       options: {
-        postPath: "src/templates/blog-post.js",
-        indexPath: "src/templates/blog-index.js",
+        postPath: "src/templates/blog-posts",
+        indexPath: "src/templates/blog-index",
       },
     },
   ],

--- a/themes/gatsby-theme-datocms-blog/gatsby-node.js
+++ b/themes/gatsby-theme-datocms-blog/gatsby-node.js
@@ -20,7 +20,7 @@ exports.createSchemaCustomization = async ({ actions }) => {
     type DatoCmsAsset implements Node & Image {
       id: ID!
       alt: String
-      gatsbyImageData: JSON
+      gatsbyImageData: JSON @imagePassthroughArguments
       originalId: String
       entityPayload: JSON
       url: String

--- a/themes/gatsby-theme-wordpress-blog/README.md
+++ b/themes/gatsby-theme-wordpress-blog/README.md
@@ -44,11 +44,9 @@ Add these two templates to your site.
 ```js
 // src/templates/blog-index.js
 import * as React from "react"
-import { graphql, Link } from "gatsby"
+import { Link } from "gatsby"
 
-export default function BlogIndex(props) {
-  const posts = props.data.allBlogPost.nodes
-
+export default function BlogIndex({ posts }) {
   return (
     <div>
       <h1>Blog</h1>
@@ -62,50 +60,24 @@ export default function BlogIndex(props) {
     </div>
   )
 }
-
-export const query = graphql`
-  query {
-    allBlogPost {
-      nodes {
-        id
-        slug
-        title
-      }
-    }
-  }
-`
 ```
 
 ```js
 // src/templates/blog-post.js
 import * as React from "react"
-import { graphql } from "gatsby"
 
 export default function BlogPost(props) {
-  const post = props.data.blogPost
-
   return (
     <div>
-      <h1>{post.title}</h1>
+      <h1>{props.title}</h1>
       <div
         dangerouslySetInnerHTML={{
-          __html: post.html,
+          __html: props.html,
         }}
       />
     </div>
   )
 }
-
-export const query = graphql`
-  query ($id: String!) {
-    blogPost(id: { eq: $id }) {
-      id
-      slug
-      title
-      html
-    }
-  }
-`
 ```
 
 ## Options
@@ -117,8 +89,8 @@ module.exports = {
     {
       resolve: "gatsby-theme-wordpress-blog",
       options: {
-        postPath: "src/templates/blog-post.js",
-        indexPath: "src/templates/blog-index.js",
+        postPath: "src/templates/blog-post",
+        indexPath: "src/templates/blog-index",
       },
     },
   ],

--- a/themes/gatsby-theme-wordpress-blog/gatsby-node.js
+++ b/themes/gatsby-theme-wordpress-blog/gatsby-node.js
@@ -1,13 +1,19 @@
 const sanitizeHTML = require("sanitize-html")
+const { getGatsbyImageResolver } = require("gatsby-plugin-image/graphql-utils")
 
 exports.createSchemaCustomization = async ({ actions }) => {
   actions.createFieldExtension({
     name: "wpImageProxy",
     extend(options) {
+      const { args } = getGatsbyImageResolver()
       return {
+        args,
         async resolve(source, args, context, info) {
           const imageType = info.schema.getType("ImageSharp")
-          const file = context.nodeModel.getNodeById(source.localFile)
+          const file = context.nodeModel.getNodeById({
+            id: source.localFile,
+          })
+          if (!file) return null
           const image = context.nodeModel.getNodeById({
             id: file.children[0],
           })
@@ -68,7 +74,7 @@ exports.createSchemaCustomization = async ({ actions }) => {
       id: ID!
       alt: String
       url: String
-      gatsbyImageData: JSON
+      gatsbyImageData: JSON @wpImageProxy
     }
   `)
 }


### PR DESCRIPTION
- Moves blog page queries into gatsby-theme-abstract-blog
  - Avoids errors/warnings when including invalid page queries in the starters when the theme isn't installed
  - Avoids the need for users to manage and maintain the query
  - Simplifies the end-user API by only requiring a render component (without GraphQL)
- Caveat: date formatting is set in the theme
- Caveat: The `gatsbyImageData` field does not include any arguments
- These caveats can be sidestepped by using the `customQueries` option and adding page queries to the blog templates