### PR TITLE
Point accessToken to same .env-var as the Starter

### DIFF
--- a/themes/gatsby-theme-contentful-blog/gatsby-config.js
+++ b/themes/gatsby-theme-contentful-blog/gatsby-config.js
@@ -5,7 +5,7 @@ module.exports = (options) => ({
       options: {
         downloadLocal: true,
         spaceId: process.env.CONTENTFUL_SPACE_ID,
-        accessToken: process.env.CONTENTFUL_DELIVERY_ACCESS_TOKEN,
+        accessToken: process.env.CONTENTFUL_ACCESS_TOKEN,
       },
     },
     {


### PR DESCRIPTION
The Contentful-Starters accessToken points to "process.env.CONTENTFUL_ACCESS_TOKEN", while the theme is pointing to "process.env.CONTENTFUL_DELIVERY_ACCESS_TOKEN", thus throwing an error when following the Tutorial in the docs, since "CONTENTFUL_DELIVERY_ACCESS_TOKEN" is not defined in the Starters config.

The Error thrown is: `"accessToken" is required`