### PR TITLE
update sanity env vars to match expected convention in cloud

### DIFF
--- a/plugins/contentful-plugin/scripts/setup.js
+++ b/plugins/contentful-plugin/scripts/setup.js
@@ -34,11 +34,6 @@ const questions = [
       "Space ID must be 12 lowercase characters",
   },
   {
-    name: "managementToken",
-    when: !argv.managementToken && !process.env.CONTENTFUL_MANAGEMENT_TOKEN,
-    message: "Your Content Management API access token",
-  },
-  {
     name: "accessToken",
     when:
       !argv.accessToken &&
@@ -46,6 +41,11 @@ const questions = [
       !argv.deliveryToken &&
       !process.env.CONTENTFUL_DELIVERY_ACCESS_TOKEN,
     message: "Your Content Delivery API access token",
+  },
+  {
+    name: "managementToken",
+    when: !argv.managementToken && !process.env.CONTENTFUL_MANAGEMENT_TOKEN,
+    message: "Your Content Management API access token",
   },
 ]
 

--- a/plugins/sanity-plugin/.env.EXAMPLE
+++ b/plugins/sanity-plugin/.env.EXAMPLE
@@ -2,5 +2,5 @@
 # with the following keys.
 # Do NOT check these files into source control
 SANITY_PROJECT_ID=""
-SANITY_DATASET=""
-SANITY_TOKEN=""
+SANITY_PROJECT_DATASET=""
+SANITY_READ_TOKEN=""

--- a/plugins/sanity-plugin/gatsby-config.js
+++ b/plugins/sanity-plugin/gatsby-config.js
@@ -9,8 +9,8 @@ module.exports = {
       resolve: "gatsby-source-sanity",
       options: {
         projectId: process.env.SANITY_PROJECT_ID,
-        dataset: process.env.SANITY_DATASET,
-        token: process.env.SANITY_TOKEN,
+        dataset: process.env.SANITY_PROJECT_DATASET,
+        token: process.env.SANITY_READ_TOKEN,
       },
     },
     "gatsby-plugin-sharp",

--- a/plugins/sanity-plugin/scripts/setup.js
+++ b/plugins/sanity-plugin/scripts/setup.js
@@ -9,8 +9,8 @@ const config = new Configstore(
     globalConfigPath: true,
   }
 )
-const token = process.env.SANITY_TOKEN || config.get("authToken")
-const dataset = process.env.SANITY_DATASET || studio.api?.dataset
+const token = process.env.SANITY_READ_TOKEN || config.get("authToken")
+const dataset = process.env.SANITY_PROJECT_DATASET || studio.api?.dataset
 const projectId = process.env.SANITY_PROJECT_ID || studio.api?.projectId
 
 if (!token) {
@@ -29,9 +29,9 @@ const content = [
   `# All environment variables will be sourced`,
   `# and made available to gatsby-config.js, gatsby-node.js, etc.`,
   `# Do NOT commit this file to source control`,
-  `SANITY_TOKEN='${token}'`,
+  `SANITY_READ_TOKEN='${token}'`,
   `SANITY_PROJECT_ID='${projectId}'`,
-  `SANITY_DATASET='${dataset}'`,
+  `SANITY_PROJECT_DATASET='${dataset}'`,
 ].join("\n")
 
 fs.writeFileSync(".env.development", content)


### PR DESCRIPTION
We had a mismatch in Cloud when adding this site where `SANITY_TOKEN` was occupying the use case that `SANITY_READ_TOKEN` should be. Additionally, `SANITY_DATASET` was occupying the use case that `SANITY_PROJECT_DATASET` should be.

This PR corrects the naming conventions in use for the starter which will alleviate any confusion for user's deploying this through the Cloud UI.