### PR TITLE
setup contentful flavor for use of gatsby-provision-contentful

### DIFF
--- a/plugins/contentful-plugin/package.json
+++ b/plugins/contentful-plugin/package.json
@@ -2,6 +2,7 @@
   "name": "contentful",
   "version": "1.0.0",
   "scripts": {
+    "gatsby-provision": "gatsby-provision-contentful --contentful-data-path='./scripts/data.json' --space-id=$CONTENTFUL_SPACE_ID --management-token=$CONTENTFUL_MANAGEMENT_TOKEN",
     "setup": "node ./scripts/setup.js",
     "export-content": "contentful space export --space-id=$SPACE_ID --management-token=$MANAGEMENT_TOKEN --export-dir=scripts --content-file=data.json"
   },
@@ -16,6 +17,7 @@
     "chalk": "4",
     "contentful-cli": "^1.10.0",
     "contentful-import": "^8.2.28",
+    "gatsby-provision-contentful": "^0.0.3",
     "inquirer": "^8.2.0",
     "yargs-parser": "^21.0.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4124,6 +4124,14 @@ chalk@4, chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1, chalk@^4.1.2:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
+  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@^1.0.0, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -4695,6 +4703,18 @@ contentful-batch-libs@^9.2.2, contentful-batch-libs@^9.3.0:
     moment "^2.29.1"
     uuid "^8.3.2"
 
+contentful-batch-libs@^9.4.1:
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/contentful-batch-libs/-/contentful-batch-libs-9.4.2.tgz#b972c37fd8127734f6eca95cdf2a0f8ba12f7272"
+  integrity sha512-G58ykBrAycBnfGEawyU2xvVnbPt32EghJ6kZo/JrKdGXYAWm+FnpeJJV0lpABvApExzoWc3ChH6eHU8X+M/w4g==
+  dependencies:
+    bfj "^7.0.2"
+    date-fns "^2.28.0"
+    figures "^3.2.0"
+    https-proxy-agent "^3.0.0"
+    lodash.clonedeep "^4.5.0"
+    uuid "^8.3.2"
+
 contentful-cli@^1.10.0:
   version "1.12.38"
   resolved "https://registry.yarnpkg.com/contentful-cli/-/contentful-cli-1.12.38.tgz#9a5c376027de06e6b8fadf9006875792438d21ec"
@@ -4773,6 +4793,24 @@ contentful-import@^8.2.25, contentful-import@^8.2.28:
     listr-verbose-renderer "^0.6.0"
     lodash "^4.17.10"
     moment "^2.22.2"
+    p-queue "^6.6.2"
+    yargs "^17.3.0"
+
+contentful-import@^8.2.29:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/contentful-import/-/contentful-import-8.3.2.tgz#49fa7695e03d266b811f6f0285f191ae652b812f"
+  integrity sha512-OQrzlSj9p2g3/kNrkQRrMxPvdxgL6iwD6E8qQzZLlVnGpZKhmZYfPBv9qZfFCHrqzj49JzwIWLkAp0b2nSGC1A==
+  dependencies:
+    bluebird "^3.5.1"
+    cli-table3 "^0.6.0"
+    contentful-batch-libs "^9.4.1"
+    contentful-management "^7.45.5"
+    date-fns "^2.28.0"
+    joi "^17.5.0"
+    listr "^0.14.1"
+    listr-update-renderer "^0.5.0"
+    listr-verbose-renderer "^0.6.0"
+    lodash "^4.17.10"
     p-queue "^6.6.2"
     yargs "^17.3.0"
 
@@ -7327,6 +7365,16 @@ gatsby-plugin-vanilla-extract@^2.0.1:
   resolved "https://registry.yarnpkg.com/gatsby-plugin-vanilla-extract/-/gatsby-plugin-vanilla-extract-2.0.1.tgz#1e370983ae8d5b8c47a3b7cb864f24d49599c02a"
   integrity sha512-D0PY99JV/E/B0tVhe22zSf8fX3ygQrXIueOsZ0qn/1fb5HVGTbj+qv5Pu7cDAOX20gkoOGdp8cvgKp75eXKKbw==
 
+gatsby-provision-contentful@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/gatsby-provision-contentful/-/gatsby-provision-contentful-0.0.3.tgz#7e60c195582ddfaca5b29dabf56b4f16588fa98d"
+  integrity sha512-D63ebkdKV+MNi12FsLdArVRhXUO5LxY9WUIJRYED6P27tZvHGZLwFoZL5ku8Gyd2gt+nK/QdN9/kgQVOytxy7Q==
+  dependencies:
+    chalk "4.1.0"
+    contentful-import "^8.2.29"
+    inquirer "^8.2.2"
+    yargs-parser "^21.0.1"
+
 gatsby-react-router-scroll@^5.15.0:
   version "5.15.0"
   resolved "https://registry.yarnpkg.com/gatsby-react-router-scroll/-/gatsby-react-router-scroll-5.15.0.tgz#d539f6fdc9d99b69961b8acb489c42871317315c"
@@ -8713,7 +8761,7 @@ inquirer@^7.0.0:
     strip-ansi "^6.0.0"
     through "^2.3.6"
 
-inquirer@^8.0.0, inquirer@^8.1.2, inquirer@^8.2.0:
+inquirer@^8.0.0, inquirer@^8.1.2, inquirer@^8.2.0, inquirer@^8.2.2:
   version "8.2.4"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.4.tgz#ddbfe86ca2f67649a67daa6f1051c128f684f0b4"
   integrity sha512-nn4F01dxU8VeKfq192IjLsxu0/OmMZ4Lg3xKAns148rCaXP6ntAoEkVYZThWjwON8AlzdZZi6oqnhNbxUG9hVg==
@@ -15252,7 +15300,7 @@ yargs-parser@^18.1.2:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^21.0.0:
+yargs-parser@^21.0.0, yargs-parser@^21.0.1:
   version "21.0.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.0.1.tgz#0267f286c877a4f0f728fceb6f8a3e4cb95c6e35"
   integrity sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==


### PR DESCRIPTION
Just updates the contentful flavor to take advantage of `gatsby-provision`!

To test, I ran `yarn publish-starters:dry-run` then went into the `gatsby-starter-contentful-homepage` dist folder and was able to successfully run `gatsby-provision`.