### PR TITLE
chore(READMEs): Use `Deploy to Gatsby Cloud` SVG instead of PNG

### DIFF
--- a/scripts/create-readmes.mjs
+++ b/scripts/create-readmes.mjs
@@ -66,7 +66,7 @@ function variablePlugin(opts) {
             node.children = [
               {
                 type: "image",
-                url: "https://www.gatsbyjs.com/deploynow.png",
+                url: "https://www.gatsbyjs.com/deploynow.svg",
                 title: "Deploy to Gatsby",
                 alt: "Deploy to Gatsby",
               },


### PR DESCRIPTION
Not sure if this change will "just work", but I noticed we're using the PNG version of the `Deploy to Gatsby Cloud` button in the Starter `README`s, which results in a blurry image on retina/hi-DPI screens (ref. e. g. https://github.com/gatsbyjs/gatsby-starter-contentful-homepage#deploy-without-using-the-cli).

This PR would change that:
- https://www.gatsbyjs.com/deploynow.png → https://www.gatsbyjs.com/deploynow.svg
- [![Deploy to Gatsby](https://www.gatsbyjs.com/deploynow.png "Deploy to Gatsby")](https://www.gatsbyjs.com/dashboard/deploynow?url=https://github.com/gatsbyjs/gatsby-starter-contentful-homepage) → [![Deploy to Gatsby](https://www.gatsbyjs.com/deploynow.svg "Deploy to Gatsby")](https://www.gatsbyjs.com/dashboard/deploynow?url=https://github.com/gatsbyjs/gatsby-starter-contentful-homepage)
