### PR TITLE
add gatsby-plugin-manifest to kontent-ai plugin

### DIFF
--- a/plugins/kontent-ai-plugin/package.json
+++ b/plugins/kontent-ai-plugin/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@kontent-ai/gatsby-source": "9.0.1",
     "@kontent-ai/gatsby-components": "9.0.1",
+    "gatsby-plugin-manifest": "^4.7.0",
     "gatsby-plugin-react-helmet": "^5.5.0",
     "react-helmet": "^6.1.0",
     "uuid": "^8.3.2"


### PR DESCRIPTION
Title says it all. We were just missing this dependency in the plugin.