### PR TITLE
Increment gatsby-plugin-vanilla-extract

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "gatsby": "^5.0.0",
     "gatsby-plugin-image": "^3.0.0",
     "gatsby-plugin-sharp": "^5.0.0",
-    "gatsby-plugin-vanilla-extract": "^2.0.1",
+    "gatsby-plugin-vanilla-extract": "^4.0.1",
     "gatsby-source-contentful": "^8.0.0",
     "gatsby-source-filesystem": "^5.0.0",
     "gatsby-transformer-sharp": "^5.0.0",


### PR DESCRIPTION
Incrementing version of gatsby-plugin-vanilla-extract to resolve conflict between plugin dependency on Gatsby v3/4 and project dependency on Gatsby v5