### PR TITLE
Remove erroneous `gatsby-source-contentful` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "gatsby-plugin-image": "^3.0.0",
     "gatsby-plugin-sharp": "^5.0.0",
     "gatsby-plugin-vanilla-extract": "^4.0.1",
-    "gatsby-source-contentful": "^8.0.0",
     "gatsby-source-filesystem": "^5.0.0",
     "gatsby-transformer-sharp": "^5.0.0",
     "is-absolute-url": "^4.0.1",


### PR DESCRIPTION
## Purpose

Noticed in the WordPress flavor of the starter that it contained the `gatsby-source-contentful` [dependency](https://github.com/gatsbyjs/gatsby-starter-wordpress-homepage/blob/main/package.json#L20), so I went ahead and removed that from the base `package.json` and verified that the `package.json` files for all the starters in a `dry-run` contain the correct corresponding source plugin.