### PR TITLE
Bump wordpress plugin

### DIFF
--- a/plugins/wordpress-plugin/package.json
+++ b/plugins/wordpress-plugin/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "gatsby-plugin-manifest": "^5.0.0",
-    "gatsby-source-wordpress": "^7.0.0"
+    "gatsby-source-wordpress": "^7.4.0"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
Noticed we've got some issues with builds of the demo site currently, and supposedly bumping to this version of the `gatsby-source-plugin` avoids the issue we're seeing: https://github.com/gatsbyjs/gatsby/issues/37114 