### PR TITLE
bump version of gatsby-provision-contentful

### DIFF
--- a/plugins/contentful-plugin/package.json
+++ b/plugins/contentful-plugin/package.json
@@ -18,7 +18,7 @@
     "chalk": "4",
     "contentful-cli": "^1.15.3",
     "contentful-import": "^8.3.2",
-    "gatsby-provision-contentful": "^0.0.3",
+    "gatsby-provision-contentful": "^0.0.5",
     "inquirer": "^8.2.0",
     "yargs-parser": "^21.0.0"
   }


### PR DESCRIPTION
## Purpose

This bumps to the latest of `gatsby-provision-contentful` which addresses an issue with pathing of where the generated `.env` files get written out to. Issue was raised to my attention here: https://github.com/gatsbyjs/gatsby-starter-landing-page/issues/45

Confirmed this is working correctly in the `dry-run` build of the contentful starter locally:

<img width="876" alt="Screen Shot 2023-01-12 at 12 24 20 PM" src="https://user-images.githubusercontent.com/1790506/212136597-f084c0a5-57b5-46eb-a4d2-edafd01b47d8.png">
