### PR TITLE
Update contentful & abstract-blog themes for Gatsby 5.5.x

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,7 +1,7 @@
 module.exports = {
   plugins: [
     // Comment and uncomment the desired CMS/backend plugin to switch between data sources
-    "contentful-plugin",
+    // "contentful-plugin",
     // "datocms-plugin",
     // "drupal-plugin",
     // "wordpress-plugin",
@@ -9,7 +9,7 @@ module.exports = {
     // "kontent-ai-plugin",
 
     // optional blog themes
-    // "gatsby-theme-contentful-blog",
+    "gatsby-theme-contentful-blog",
     // "gatsby-theme-datocms-blog",
     // "gatsby-theme-wordpress-blog",
   ],

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,7 +1,7 @@
 module.exports = {
   plugins: [
     // Comment and uncomment the desired CMS/backend plugin to switch between data sources
-    // "contentful-plugin",
+    "contentful-plugin",
     // "datocms-plugin",
     // "drupal-plugin",
     // "wordpress-plugin",
@@ -9,7 +9,7 @@ module.exports = {
     // "kontent-ai-plugin",
 
     // optional blog themes
-    "gatsby-theme-contentful-blog",
+    // "gatsby-theme-contentful-blog",
     // "gatsby-theme-datocms-blog",
     // "gatsby-theme-wordpress-blog",
   ],

--- a/themes/gatsby-theme-abstract-blog/package.json
+++ b/themes/gatsby-theme-abstract-blog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-theme-abstract-blog",
-  "version": "1.0.0-3",
+  "version": "1.0.0-4",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {}

--- a/themes/gatsby-theme-abstract-blog/src/index.js
+++ b/themes/gatsby-theme-abstract-blog/src/index.js
@@ -10,7 +10,7 @@ export default function BlogIndexQuery(props) {
 
 export const query = graphql`
   query {
-    allBlogPost(sort: { fields: date, order: DESC }) {
+    allBlogPost(sort: {date: DESC}) {
       nodes {
         id
         slug

--- a/themes/gatsby-theme-contentful-blog/package.json
+++ b/themes/gatsby-theme-contentful-blog/package.json
@@ -4,13 +4,13 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@contentful/rich-text-html-renderer": "^15.11.1",
-    "gatsby-plugin-image": "^3.0.0",
-    "gatsby-plugin-sharp": "^5.0.0",
-    "gatsby-source-contentful": "^8.0.0",
+    "@contentful/rich-text-html-renderer": "^16.0.2",
+    "gatsby-plugin-image": "^3.5.0",
+    "gatsby-plugin-sharp": "^5.5.0",
+    "gatsby-source-contentful": "^8.5.0",
     "gatsby-theme-abstract-blog": "1.0.0-3",
-    "gatsby-transformer-remark": "^6.0.0",
-    "gatsby-transformer-sharp": "^5.0.0",
-    "sharp": "^0.29.3"
+    "gatsby-transformer-remark": "^6.5.0",
+    "gatsby-transformer-sharp": "^5.5.0",
+    "sharp": "^0.30.5"
   }
 }

--- a/themes/gatsby-theme-contentful-blog/package.json
+++ b/themes/gatsby-theme-contentful-blog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-theme-contentful-blog",
-  "version": "1.0.0-4",
+  "version": "1.0.0-5",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Minor changes to dependencies, and updated graphGL syntax.  Once released, "gatsby-theme-abstract-blog" entry in gatsby-theme-contentful-blog/package.json would also need to be updated to "1.0.0-4" if merged with the main branch.  

Cheers!