### PR TITLE
Adjust contentful README

### DIFF
--- a/plugins/contentful-plugin/README.md
+++ b/plugins/contentful-plugin/README.md
@@ -15,6 +15,8 @@ This version of the Contentful homepage starter is written in JavaScript. If you
 
 You will need a new or existing [Contentful space][] to use this starter and will be asked for your [Space ID][], [Content Management API Key][] (also referred to as a Personal Access Token) and [Content Delivery API Key][] during installation.
 
+**Note:** Contentful recently adjusted their limitations for free spaces and it is affecting this starter. Free spaces are only allowed to have 25 content types, and this starter currently utilizes 27. We'll be adjusting the associated content in the starter in the next week to work within these new limitations so you all can still experiment with the Contentful and Gatsby stack. Thank you for you understanding.
+
 [contentful space]: https://www.contentful.com/help/contentful-101/#step-2-create-a-space
 [space id]: https://www.contentful.com/help/find-space-id/
 [content delivery api key]: https://www.contentful.com/developers/docs/references/authentication/#api-keys-in-the-contentful-web-app

--- a/plugins/contentful-plugin/TS-README.md
+++ b/plugins/contentful-plugin/TS-README.md
@@ -15,6 +15,8 @@ This version of the Contentful homepage starter is written in TypeScript. If you
 
 You will need a new or existing [Contentful space][] to use this starter and will be asked for your [Space ID][], [Content Management API Key][] (also referred to as a Personal Access Token) and [Content Delivery API Key][] during installation.
 
+**Note:** Contentful recently adjusted their limitations for free spaces and it is affecting this starter. Free spaces are only allowed to have 25 content types, and this starter currently utilizes 27. We'll be adjusting the associated content in the starter in the next week to work within these new limitations so you all can still experiment with the Contentful and Gatsby stack. Thank you for you understanding.
+
 [contentful space]: https://www.contentful.com/help/contentful-101/#step-2-create-a-space
 [space id]: https://www.contentful.com/help/find-space-id/
 [content delivery api key]: https://www.contentful.com/developers/docs/references/authentication/#api-keys-in-the-contentful-web-app

--- a/plugins/contentful-plugin/docs/quick-start-intro.md
+++ b/plugins/contentful-plugin/docs/quick-start-intro.md
@@ -1,5 +1,7 @@
 You will need a new or existing [Contentful space][] to use this starter and will be asked for your [Space ID][], [Content Management API Key][] (also referred to as a Personal Access Token) and [Content Delivery API Key][] during installation.
 
+**Note:** Contentful recently adjusted their limitations for free spaces and it is affecting this starter. Free spaces are only allowed to have 25 content types, and this starter currently utilizes 27. We'll be adjusting the associated content in the starter in the next week to work within these new limitations so you all can still experiment with the Contentful and Gatsby stack. Thank you for you understanding.
+
 [contentful space]: https://www.contentful.com/help/contentful-101/#step-2-create-a-space
 [space id]: https://www.contentful.com/help/find-space-id/
 [content delivery api key]: https://www.contentful.com/developers/docs/references/authentication/#api-keys-in-the-contentful-web-app


### PR DESCRIPTION
## Purpose

Contentful recently applied more limitations to free spaces and that is affecting this starter as it utilizes 27 content types, whereas the new limit is 25.

I'll be adjusting the Contentful flavor of the starter in the coming week, but it's not a quick and easy PR. So for now, I'm electing to add a note in the READMEs.